### PR TITLE
Implement news archive pagination

### DIFF
--- a/app/(other-routes)/news/page.tsx
+++ b/app/(other-routes)/news/page.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 
 import Pagination from "@/components/pagination";
@@ -6,14 +7,11 @@ import NewsArchiveBlock from "@/components/news/news-archive-block";
 import type { NewsItem } from "@/components/news/types";
 import newsData from "@/data/news.json";
 import styles from "@/styles/NewsArchiveBlock.module.css";
-import { createTranslatedMetadata } from "@/utils/generate-metadata";
 import { DEFAULT_PAGE_SIZE, paginateArray } from "@/utils/pagination";
 
-export const metadata = () => createTranslatedMetadata("Pages", "news");
-
-export function generateMetadata({
+export async function generateMetadata({
   searchParams,
-}: NewsPageProps): Metadata | Promise<Metadata> {
+}: NewsPageProps): Promise<Metadata> {
   const page = Number.parseInt(
     Array.isArray(searchParams?.page) ? searchParams?.page[0] ?? "1" : searchParams?.page ?? "1",
     10,
@@ -21,8 +19,10 @@ export function generateMetadata({
   const total = Math.max(1, Math.ceil((newsData as unknown as NewsItem[]).length / DEFAULT_PAGE_SIZE));
   const current = Number.isFinite(page) && page >= 1 ? Math.min(page, total) : 1;
   const base = "/news";
+  const t = await getTranslations("Pages");
+  const baseTitle = t("news");
   return {
-    title: `Cyclist.fi | News${current > 1 ? ` – Page ${current}` : ""}`,
+    title: `Cyclist.fi | ${baseTitle}${current > 1 ? ` – Page ${current}` : ""}`,
     alternates: {
       canonical: current === 1 ? base : `${base}?page=${current}`,
     },

--- a/app/(other-routes)/news/page.tsx
+++ b/app/(other-routes)/news/page.tsx
@@ -1,26 +1,56 @@
 import { useTranslations } from "next-intl";
+import type { Metadata } from "next";
 
+import Pagination from "@/components/pagination";
 import NewsArchiveBlock from "@/components/news/news-archive-block";
+import type { NewsItem } from "@/components/news/types";
 import newsData from "@/data/news.json";
 import styles from "@/styles/NewsArchiveBlock.module.css";
 import { createTranslatedMetadata } from "@/utils/generate-metadata";
+import { DEFAULT_PAGE_SIZE, paginateArray } from "@/utils/pagination";
 
 export const metadata = () => createTranslatedMetadata("Pages", "news");
 
-interface NewsItem {
-  id: string;
-  image: string;
-  text: string;
-  date: string;
+export function generateMetadata({
+  searchParams,
+}: NewsPageProps): Metadata | Promise<Metadata> {
+  const page = Number.parseInt(
+    Array.isArray(searchParams?.page) ? searchParams?.page[0] ?? "1" : searchParams?.page ?? "1",
+    10,
+  );
+  const total = Math.max(1, Math.ceil((newsData as unknown as NewsItem[]).length / DEFAULT_PAGE_SIZE));
+  const current = Number.isFinite(page) && page >= 1 ? Math.min(page, total) : 1;
+  const base = "/news";
+  return {
+    title: `Cyclist.fi | News${current > 1 ? ` – Page ${current}` : ""}`,
+    alternates: {
+      canonical: current === 1 ? base : `${base}?page=${current}`,
+    },
+  };
 }
 
-export default function News() {
+type NewsPageProps = {
+  searchParams?: { [key: string]: string | string[] | undefined };
+};
+
+export default function News({ searchParams }: NewsPageProps) {
   const t = useTranslations("Pages");
+
+  const rawPage = searchParams?.page;
+  const pageParam = Array.isArray(rawPage)
+    ? rawPage[0]
+    : (rawPage ?? "1");
+  const requestedPage = Number.isFinite(Number.parseInt(pageParam, 10))
+    ? Number.parseInt(pageParam, 10)
+    : 1;
+
+  const allNews = newsData as unknown as NewsItem[];
+  const paginated = paginateArray(allNews, requestedPage, DEFAULT_PAGE_SIZE);
 
   return (
     <div>
       <h1 className={styles.title}>{t("news")}</h1>
-      {newsData.map((newsItem: NewsItem) => (
+      {paginated.items.map((newsItem: NewsItem) => (
         <NewsArchiveBlock
           key={newsItem.id}
           image={newsItem.image}
@@ -28,6 +58,12 @@ export default function News() {
           date={newsItem.date}
         />
       ))}
+      <Pagination
+        basePath="/news"
+        currentPage={paginated.currentPage}
+        totalPages={paginated.totalPages}
+        ariaLabel={`${t("news")} pagination`}
+      />
     </div>
   );
 }

--- a/components/news/news-archive-block.tsx
+++ b/components/news/news-archive-block.tsx
@@ -6,7 +6,7 @@ import { NewsItem } from "./types";
 
 export default function NewsArchiveBlock({ image, text, date }: NewsItem) {
   return (
-    <section className={styles.newsArchiveBlock}>
+    <section className={styles.newsArchiveBlock} aria-label={date}>
       <div aria-hidden="true">
         <Image
           fill

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -19,10 +19,9 @@ export default function Pagination({
 }: PaginationProps) {
   const t = useTranslations("Common");
   const searchParams = useSearchParams();
-  const entries = searchParams?.entries();
 
   const buildHref = (page: number) => {
-    const params = new URLSearchParams(entries ?? undefined);
+    const params = new URLSearchParams(searchParams?.toString() ?? undefined);
     if (page === 1) {
       params.delete("page");
     } else {

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
+
+interface PaginationProps {
+  basePath: string;
+  currentPage: number;
+  totalPages: number;
+  ariaLabel?: string;
+}
+
+export default function Pagination({
+  basePath,
+  currentPage,
+  totalPages,
+  ariaLabel,
+}: PaginationProps) {
+  const t = useTranslations("Common");
+  const searchParams = useSearchParams();
+  const entries = searchParams?.entries();
+
+  const buildHref = (page: number) => {
+    const params = new URLSearchParams(entries ?? undefined);
+    if (page === 1) {
+      params.delete("page");
+    } else {
+      params.set("page", String(page));
+    }
+    const query = params.toString();
+    return query ? `${basePath}?${query}` : basePath;
+  };
+
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
+
+  return (
+    <nav aria-label={ariaLabel ?? t("pagination")} style={{ display: "flex", gap: "0.5rem", justifyContent: "center", margin: "2rem 0" }}>
+      <Link
+        href={hasPrev ? buildHref(currentPage - 1) : "#"}
+        aria-disabled={!hasPrev}
+        aria-label="Previous page"
+        rel={hasPrev ? "prev" : undefined}
+        style={{ pointerEvents: hasPrev ? undefined : "none", opacity: hasPrev ? 1 : 0.5 }}
+      >
+        ← {t("prev")}
+      </Link>
+      <span aria-current="page">{currentPage}</span>
+      <span>/</span>
+      <span>{totalPages}</span>
+      <Link
+        href={hasNext ? buildHref(currentPage + 1) : "#"}
+        aria-disabled={!hasNext}
+        aria-label="Next page"
+        rel={hasNext ? "next" : undefined}
+        style={{ pointerEvents: hasNext ? undefined : "none", opacity: hasNext ? 1 : 0.5 }}
+      >
+        {t("next")} →
+      </Link>
+    </nav>
+  );
+}

--- a/styles/NewsArchiveBlock.module.css
+++ b/styles/NewsArchiveBlock.module.css
@@ -66,6 +66,11 @@ div:has(.newsArchiveBlock) {
   z-index: -1;
 }
 
+nav[aria-label="Pagination"] a[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
 @media (width < 1100px) {
   div:has(.newsArchiveBlock) {
     margin-block-start: -4.5rem;

--- a/styles/NewsArchiveBlock.module.css
+++ b/styles/NewsArchiveBlock.module.css
@@ -66,11 +66,6 @@ div:has(.newsArchiveBlock) {
   z-index: -1;
 }
 
-nav[aria-label="Pagination"] a[aria-disabled="true"] {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
 @media (width < 1100px) {
   div:has(.newsArchiveBlock) {
     margin-block-start: -4.5rem;

--- a/translations/en.json
+++ b/translations/en.json
@@ -14,7 +14,10 @@
     "skipLinks_label": "Links to main content and contacts",
     "skipLinks_mainContent": "Skip to main content",
     "skipLinks_contacts": "Skip to contact links",
-    "new": "New"
+    "new": "New",
+    "pagination": "Pagination",
+    "prev": "Prev",
+    "next": "Next"
   },
   "Pages": {
     "apparel": "Apparel",

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -14,7 +14,10 @@
     "skipLinks_label": "Linkit: pääsisältö ja yhteystiedot",
     "skipLinks_mainContent": "Siirry pääsisältöön",
     "skipLinks_contacts": "Siirry yhteystietoihin",
-    "new": "Uusi"
+    "new": "Uusi",
+    "pagination": "Sivutus",
+    "prev": "Edellinen",
+    "next": "Seuraava"
   },
   "Pages": {
     "apparel": "Vaatteet",

--- a/utils/__tests__/pagination.test.ts
+++ b/utils/__tests__/pagination.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { getTotalPages, paginateArray, sanitizePage } from "@/utils/pagination";
+
+describe("pagination utils", () => {
+  it("computes total pages correctly", () => {
+    expect(getTotalPages(0, 6)).toBe(1);
+    expect(getTotalPages(1, 6)).toBe(1);
+    expect(getTotalPages(6, 6)).toBe(1);
+    expect(getTotalPages(7, 6)).toBe(2);
+  });
+
+  it("sanitizes page within bounds", () => {
+    expect(sanitizePage(0, 10)).toBe(1);
+    expect(sanitizePage(11, 10)).toBe(10);
+    expect(sanitizePage(5, 10)).toBe(5);
+  });
+
+  it("paginates arrays", () => {
+    const items = Array.from({ length: 13 }, (_, i) => i + 1);
+    const page1 = paginateArray(items, 1, 6);
+    expect(page1.items).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(page1.totalPages).toBe(3);
+
+    const page3 = paginateArray(items, 3, 6);
+    expect(page3.items).toEqual([13]);
+  });
+});

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -1,0 +1,49 @@
+export interface PaginationMeta {
+  currentPage: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+}
+
+export interface PaginatedResult<T> extends PaginationMeta {
+  items: T[];
+}
+
+export const DEFAULT_PAGE_SIZE = 6;
+
+export function getTotalPages(totalItems: number, pageSize: number): number {
+  if (pageSize <= 0) return 0;
+  return Math.max(1, Math.ceil(totalItems / pageSize));
+}
+
+export function sanitizePage(page: number, totalPages: number): number {
+  if (!Number.isFinite(page) || page < 1) return 1;
+  if (page > totalPages) return totalPages;
+  return page;
+}
+
+export function paginateArray<T>(
+  allItems: readonly T[],
+  requestedPage: number,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): PaginatedResult<T> {
+  const totalItems = allItems.length;
+  const totalPages = getTotalPages(totalItems, pageSize);
+  const currentPage = sanitizePage(requestedPage, totalPages);
+
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = startIndex + pageSize;
+  const items = allItems.slice(startIndex, endIndex);
+
+  return {
+    items,
+    currentPage,
+    pageSize,
+    totalItems,
+    totalPages,
+    hasPreviousPage: currentPage > 1,
+    hasNextPage: currentPage < totalPages,
+  };
+}

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -9,6 +9,7 @@ vi.mock("next/navigation", () => {
   const push = vi.fn();
   return {
     useRouter: () => ({ push }),
+    useSearchParams: () => new URLSearchParams(),
   };
 });
 


### PR DESCRIPTION
Implement pagination for the news archive page (fixes #29) using a new reusable pagination component and utility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a07f2a9d-3e05-4c99-bd33-9160a5f850aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a07f2a9d-3e05-4c99-bd33-9160a5f850aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

